### PR TITLE
[MTS][123233931] Fix SVG bug

### DIFF
--- a/src/reducers/Element.js
+++ b/src/reducers/Element.js
@@ -19,7 +19,7 @@ export default class ElementReducer {
 
   getStack(element) {
     const stack = []
-    let node = element
+    let node = element.correspondingElement || element
     while (node) {
       stack.push(node)
       node = node.parentNode
@@ -58,7 +58,7 @@ export default class ElementReducer {
 
   getAtts(element) {
     const atts = {}
-    const href = element.getAttribute && element.getAttribute('href')
+    const href = element.getAttribute('href')
     if (href && !href.match(/^(?:javascript|#)/)) {
       atts.href = href
     }

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -22,4 +22,10 @@
     <div id="nested-item" data-tag_item="bar"></div>
   </div>
 
+  <svg>
+    <symbol viewBox="0 0 16 10">
+      <title>arrow_down</title>
+      <path id='path' d="M0 1.745l7.994 8.268 8.002-8.277L14.318 0 7.994 6.541 1.678.009 0 1.745" fill-rule="evenodd"/>
+    </symbol>
+  </svg>
 </div>

--- a/test/reducers/Element.js
+++ b/test/reducers/Element.js
@@ -20,6 +20,16 @@ describe('ElementReducer', function() {
   beforeEach(function() {
     const reducer = new ElementReducer()
     this.reduce = reducer.reduce.bind(reducer)
+    this.getStack = reducer.getStack.bind(reducer)
+  })
+
+  describe('#getStack', function() {
+    it('handles objects like SVGElementInstance', function() {
+      const svgElementInstance = { correspondingElement: document.getElementById('path') }
+      const result = this.getStack(svgElementInstance)
+      expect(result.length).to.equal(6)
+      expect(result[5]).to.equal(svgElementInstance.correspondingElement)
+    })
   })
 
   describe('#reduce', function() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/123233931

In the MS Edge browser, the event tracker was picking up an object that
wasn't a normal HTML element. It was an `SVGElementInstance` object. It
did not have a `getAttribute()` method or an attributes property.

While the addition of a check for the existence of a `getAttribute()`
method on the element in `getAtts()` was helpful, the event tracker still
would not have worked with MS Edge, since `getTags()` used
`element.attributes`, and passed this value to `Object.keys()`. In the case
of an `SVGElementInstance` object, this would result in `Object.keys()`
evaluating undefined, and would raise an error.

To circumvent this, we use the object's `correspondingElement` property
higher up in the call stack as the node. For an `SVGElementInstance`, this
will be an HTML element that will work with the rest of the event
tracker code. For a normal HTML element, this will result in undefined,
and we end up using the original element as our node.