### PR TITLE
Chore to add 'onFocus' events

### DIFF
--- a/src/trackers/Focus.js
+++ b/src/trackers/Focus.js
@@ -1,11 +1,21 @@
-import EventTracker from './Event'
+export default class FocusTracker {
+  constructor(config, tracker) {
+    this.config = { ...config }
+    this.tracker = tracker
+    this.addListener()
+  }
 
-export default class FocusTracker extends EventTracker {
+  track(...args) {
+    this.tracker.track(...args)
+  }
+
+  addListener() {
+    document.addEventListener('focus', event => this.track('focus', { event }), { capture: true })
+  }
+
   get defaults() {
     return {
-      events: {
-        focus: 'focus',
-      },
+      events: {},
     }
   }
 }

--- a/src/trackers/Focus.js
+++ b/src/trackers/Focus.js
@@ -12,10 +12,4 @@ export default class FocusTracker {
   addListener() {
     document.addEventListener('focus', event => this.track('focus', { event }), { capture: true })
   }
-
-  get defaults() {
-    return {
-      events: {},
-    }
-  }
 }

--- a/src/trackers/Focus.js
+++ b/src/trackers/Focus.js
@@ -1,0 +1,11 @@
+import EventTracker from './Event'
+
+export default class FocusTracker extends EventTracker {
+  get defaults() {
+    return {
+      events: {
+        focus: 'focus',
+      },
+    }
+  }
+}

--- a/src/trackers/index.js
+++ b/src/trackers/index.js
@@ -2,10 +2,12 @@ import Click from './Click'
 import Event from './Event'
 import Select from './Select'
 import View from './View'
+import Focus from './Focus'
 
 export default {
   Click,
   Event,
   Select,
   View,
+  Focus,
 }

--- a/test/trackers/Focus.js
+++ b/test/trackers/Focus.js
@@ -1,0 +1,20 @@
+import sinon from 'sinon'
+import { expect } from 'chai'
+import FocusTracker from '../../src/trackers/Focus'
+
+describe('FocusTracker', function() {
+  beforeEach(function() {
+    this.jsdom = require('jsdom-global')()
+    this.spy = sinon.spy()
+    this.tracker = new FocusTracker(null, { track: this.spy })
+  })
+
+  afterEach(function() {
+    this.jsdom()
+  })
+
+  it('triggers an action for focus events', function() {
+    document.dispatchEvent(new Event('focus'))
+    expect(this.spy.called).to.be.true
+  })
+})


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/150755312)

 - Adds support for `onFocus` events, as a new tracker type.
 - Adds test to verify new event tracker gets called.