### PR TITLE
Only trigger focus events for inputs

### DIFF
--- a/src/trackers/Focus.js
+++ b/src/trackers/Focus.js
@@ -2,6 +2,7 @@ export default class FocusTracker {
   constructor(config, tracker) {
     this.config = { ...config }
     this.tracker = tracker
+    this.handleFocus = this.handleFocus.bind(this)
     this.addListener()
   }
 
@@ -9,7 +10,17 @@ export default class FocusTracker {
     this.tracker.track(...args)
   }
 
+  canTrack(node) {
+    return node && !!(~['INPUT', 'TEXTAREA', 'SELECT'].indexOf(node.nodeName))
+  }
+
+  handleFocus(event) {
+    if (this.canTrack(event.target)) {
+      this.track('focus', { event })
+    }
+  }
+
   addListener() {
-    document.addEventListener('focus', event => this.track('focus', { event }), { capture: true })
+    document.addEventListener('focus', this.handleFocus, { capture: true })
   }
 }

--- a/test/trackers/Focus.js
+++ b/test/trackers/Focus.js
@@ -13,8 +13,31 @@ describe('FocusTracker', function() {
     this.jsdom()
   })
 
-  it('triggers an action for focus events', function() {
-    document.dispatchEvent(new Event('focus'))
+  it('triggers a focus action for input elements', function() {
+    const event = new Event('focus')
+    Object.defineProperty(event, 'target', { value: { nodeName: 'INPUT' } })
+    document.dispatchEvent(event)
     expect(this.spy.called).to.be.true
+  })
+
+  it('triggers a focus action for select elements', function() {
+    const event = new Event('focus')
+    Object.defineProperty(event, 'target', { value: { nodeName: 'SELECT' } })
+    document.dispatchEvent(event)
+    expect(this.spy.called).to.be.true
+  })
+
+  it('triggers a focus action for textarea elements', function() {
+    const event = new Event('focus')
+    Object.defineProperty(event, 'target', { value: { nodeName: 'TEXTAREA' } })
+    document.dispatchEvent(event)
+    expect(this.spy.called).to.be.true
+  })
+
+  it('does not trigger a focus action for anchor elements', function() {
+    const event = new Event('focus')
+    Object.defineProperty(event, 'target', { value: { nodeName: 'A' } })
+    document.dispatchEvent(event)
+    expect(this.spy.called).to.be.false
   })
 })


### PR DESCRIPTION
Updates `Focus` tracker to only fire for input elements (including select and textarea).