### PR TITLE
GTM:Fixes Internal Redirects and Transpiler 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,0 @@
-const EventTracker = require('./lib/EventTracker')
-const { iframe, iframeSrc } = require('./lib/noscripts/gtm')
-
-EventTracker.gtmIframe = iframe
-EventTracker.gtmIframeSrc = iframeSrc
-
-module.exports = EventTracker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/event-tracker",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.0.1",
+  "version": "6.1.0",
   "name": "@rentpath/event-tracker",
   "description": "Capture and deliver user events.",
   "license": "MIT",
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/rentpath/event-tracker.js/issues"
   },
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "clean": "rm -rf lib",
     "build": "babel -d lib src",

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+export default from './EventTracker'
+
+export { gtmIframe, gtmIframeSrc } from './noscripts/gtm'

--- a/src/noscripts/gtm.js
+++ b/src/noscripts/gtm.js
@@ -1,3 +1,3 @@
-export const iframeSrc = config => `//www.googletagmanager.com/ns.html?id=${config.gtmId || undefined}&gtm_auth=${config.gtmAuth || ''}&gtm_preview=${config.gtmPreview || ''}&gtm_cookies_win=x`
+export const gtmIframeSrc = config => `https://www.googletagmanager.com/ns.html?id=${config.gtmId || undefined}&gtm_auth=${config.gtmAuth || ''}&gtm_preview=${config.gtmPreview || ''}&gtm_cookies_win=x`
 
-export const iframe = config => `<iframe src="${iframeSrc(config)}" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
+export const gtmIframe = config => `<iframe src="${gtmIframeSrc(config)}" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`

--- a/src/providers/GoogleTagManager.js
+++ b/src/providers/GoogleTagManager.js
@@ -10,7 +10,7 @@ export default class GoogleTagManager {
 
   get url() {
     const { gtmAuth, gtmPreview, gtmId } = this.config
-    return `//www.googletagmanager.com/gtm.js?id=${gtmId}&gtm_auth=${gtmAuth}&gtm_preview=${gtmPreview}&gtm_cookies_win=x`
+    return `https://www.googletagmanager.com/gtm.js?id=${gtmId}&gtm_auth=${gtmAuth}&gtm_preview=${gtmPreview}&gtm_cookies_win=x`
   }
 
   reset() {

--- a/test/noscripts/gtm.js
+++ b/test/noscripts/gtm.js
@@ -1,17 +1,17 @@
 import { expect } from 'chai'
-import { iframe, iframeSrc } from '../../src/noscripts/gtm'
+import { gtmIframe, gtmIframeSrc } from '../../src/noscripts/gtm'
 
 describe('utils/sanitize', function() {
   it('calling iframe with empty config', function() {
-    expect(iframe({})).to.eql('<iframe src="//www.googletagmanager.com/ns.html?id=undefined&gtm_auth=&gtm_preview=&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>')
+    expect(gtmIframe({})).to.eql('<iframe src="https://www.googletagmanager.com/ns.html?id=undefined&gtm_auth=&gtm_preview=&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>')
   })
   it('calling iframe with config', function() {
-    expect(iframe({ gtmId: 'test', gtmAuth: 'auth', gtmPreview: 'preview' })).to.eql('<iframe src="//www.googletagmanager.com/ns.html?id=test&gtm_auth=auth&gtm_preview=preview&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>')
+    expect(gtmIframe({ gtmId: 'test', gtmAuth: 'auth', gtmPreview: 'preview' })).to.eql('<iframe src="https://www.googletagmanager.com/ns.html?id=test&gtm_auth=auth&gtm_preview=preview&gtm_cookies_win=x" height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>')
   })
   it('calling iframeSrc with empty config', function() {
-    expect(iframeSrc({})).to.eql('//www.googletagmanager.com/ns.html?id=undefined&gtm_auth=&gtm_preview=&gtm_cookies_win=x')
+    expect(gtmIframeSrc({})).to.eql('https://www.googletagmanager.com/ns.html?id=undefined&gtm_auth=&gtm_preview=&gtm_cookies_win=x')
   })
   it('calling iframeSrc with config', function() {
-    expect(iframeSrc({ gtmId: 'test', gtmAuth: 'auth', gtmPreview: 'preview' })).to.eql('//www.googletagmanager.com/ns.html?id=test&gtm_auth=auth&gtm_preview=preview&gtm_cookies_win=x')
+    expect(gtmIframeSrc({ gtmId: 'test', gtmAuth: 'auth', gtmPreview: 'preview' })).to.eql('https://www.googletagmanager.com/ns.html?id=test&gtm_auth=auth&gtm_preview=preview&gtm_cookies_win=x')
   })
 })

--- a/test/providers/GoogleTagManager.js
+++ b/test/providers/GoogleTagManager.js
@@ -36,7 +36,7 @@ describe('GoogleTagManager', function() {
       const gtm = new GoogleTagManager(config)
       gtm.loadWithData()
       expect(document.getElementsByTagName('script')[0].src).to
-      .equal('//www.googletagmanager.com/gtm.js?id=test&gtm_auth=&gtm_preview=env-test&gtm_cookies_win=x')
+      .equal('https://www.googletagmanager.com/gtm.js?id=test&gtm_auth=&gtm_preview=env-test&gtm_cookies_win=x')
     })
   })
 })


### PR DESCRIPTION
Fixes for
1. Arrow functions are not transpiring converting to static functions.

app-f907918f3c92148eed53.js from UglifyJs
Name expected [./node_modules/event-tracker/index.js:2,0][app-f907918f3c92148eed53.js:32287,6]

2. We are seeing two requests in network calls - HTTP Status (Internal redirect 307)
[Reference Link](https://stackoverflow.com/questions/27945501/307-redirect-when-loading-analytics-js-in-chrome)
