### PR TITLE
Adding ecommerce tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rentpath/event-tracker",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.1.2",
+  "version": "6.2.0",
   "name": "@rentpath/event-tracker",
   "description": "Capture and deliver user events.",
   "license": "MIT",

--- a/src/reducers/Ecommerce.js
+++ b/src/reducers/Ecommerce.js
@@ -1,0 +1,73 @@
+import cookie from 'cookie'
+
+export default class EcommerceReducer {
+
+  constructor(config = {}) {
+    this.config = Object.assign(this.defaults, config)
+  }
+
+  requestId() {
+    return (Date.now() + Math.floor((1 + Math.random()) * 1000))
+  }
+
+  getStorageData(key) {
+    return window.sessionStorage ? window.sessionStorage.getItem(key) : undefined
+  }
+
+  setStorageData(key, value) {
+    if (window.sessionStorage) window.sessionStorage.setItem(key, value)
+  }
+
+  adjustedTotal(selection, screenType, campaignId, revenue) {
+    let factor = 1
+
+    if (selection === 'email' && screenType === 'desktop') {
+      factor = 2
+      if (campaignId) factor = 1.75
+    }
+    return revenue && !isNaN(revenue) ? (parseFloat(revenue) * factor)
+      : revenue
+  }
+
+  reduce(data = {}) {
+    if (!data.action || data.action !== 'lead_submission') {
+      return data
+    }
+    const {
+      sessionKey,
+      campaignKey,
+    } = this.config
+    const cookies = cookie.parse(document.cookie)
+    const sessionId = cookies[sessionKey]
+    const listingId = data.listing_id
+    const revenue = data.revenue
+    const selection = data.selection
+    const transactionId = this.requestId()
+    const uniqueSubmission = this.getStorageData(`${sessionId}_${listingId}`) ? 'false' : 'true'
+    const transactionAdjustedTotal = this.adjustedTotal(selection,
+      data.screen_type, cookies[campaignKey], revenue)
+    this.setStorageData(`${sessionId}_${listingId}`, true)
+
+    return Object.assign(data, {
+      transactionId,
+      transactionAffiliation: selection,
+      transactionAdjustedTotal,
+      transactionTotal: revenue,
+      uniqueSubmission,
+      transactionProducts: `[{
+        sku: ${listingId},
+        name: ${listingId},
+        category: ${selection},
+        price: ${revenue},
+        quantity: 1,
+      }]`,
+    })
+  }
+
+  get defaults() {
+    return {
+      campaignKey: 'campaign_id',
+      sessionKey: 'rp_session_id',
+    }
+  }
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,7 @@ import Request from './Request'
 import Session from './Session'
 import Event from './Event'
 import TagManagerEvent from './TagManagerEvent'
+import Ecommerce from './Ecommerce'
 
 export default {
   Browser,
@@ -16,4 +17,5 @@ export default {
   Session,
   Event,
   TagManagerEvent,
+  Ecommerce,
 }

--- a/test/reducers/Ecommerce.js
+++ b/test/reducers/Ecommerce.js
@@ -1,0 +1,236 @@
+import sinon from 'sinon'
+import { expect } from 'chai'
+import EcommerceReducer from '../../src/reducers/Ecommerce'
+
+describe('EcommerceReducer', function() {
+  beforeEach(function() {
+    this.jsdom = require('jsdom-global')()
+    this.stub = sinon.stub(EcommerceReducer.prototype, 'requestId').returns('123')
+    this.stub2 = sinon.stub(EcommerceReducer.prototype, 'getStorageData').returns(false)
+    this.stub3 = sinon.stub(EcommerceReducer.prototype, 'setStorageData')
+  })
+
+  afterEach(function() {
+    this.jsdom()
+    this.stub.restore()
+    this.stub2.restore()
+    this.stub3.restore()
+  })
+
+  describe('#reduce', function() {
+    it('does nothing unless action is provided', function() {
+      const reducer = new EcommerceReducer()
+      expect(reducer.reduce()).to.eql({})
+    })
+
+    it('does nothing unless action is lead_submission', function() {
+      const reducer = new EcommerceReducer()
+      expect(reducer.reduce({ action: 'click' })).to.eql({ action: 'click' })
+    })
+
+    it('adds transaction tags for lead_submission action', function() {
+      const reducer = new EcommerceReducer()
+      const expected = {
+        action: 'lead_submission',
+        transactionAdjustedTotal: undefined,
+        transactionAffiliation: undefined,
+        transactionId: '123',
+        transactionTotal: undefined,
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: undefined,
+        name: undefined,
+        category: undefined,
+        price: undefined,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce({ action: 'lead_submission' })).to.eql(expected)
+    })
+    it('checks uniqueSubmission is true', function() {
+      document.cookie = 'rp_session_id=abc'
+      const reducer = new EcommerceReducer()
+      const expected = {
+        action: 'lead_submission',
+        transactionAdjustedTotal: undefined,
+        transactionAffiliation: 'email',
+        listing_id: '1234',
+        selection: 'email',
+        transactionId: '123',
+        transactionTotal: undefined,
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: email,
+        price: undefined,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce({ action: 'lead_submission', listing_id: '1234', selection: 'email' })).to.eql(expected)
+    })
+    it('checks uniqueSubmission is false', function() {
+      document.cookie = 'rp_session_id=abc'
+      this.stub2.restore()
+      this.stub2 = sinon.stub(EcommerceReducer.prototype, 'getStorageData').returns(true)
+      const reducer = new EcommerceReducer()
+      const expected = {
+        action: 'lead_submission',
+        transactionAdjustedTotal: undefined,
+        transactionAffiliation: 'email',
+        listing_id: '1234',
+        selection: 'email',
+        transactionId: '123',
+        transactionTotal: undefined,
+        uniqueSubmission: 'false',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: email,
+        price: undefined,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce({ action: 'lead_submission', listing_id: '1234', selection: 'email' })).to.eql(expected)
+    })
+    it('checks transactionAdjustedTotal is twice of transactionTotal for desktop email lead with no campaign_id', function() {
+      document.cookie = 'rp_session_id=abc'
+      const reducer = new EcommerceReducer()
+      const data = {
+        action: 'lead_submission',
+        listing_id: '1234',
+        selection: 'email',
+        revenue: '20',
+        screen_type: 'desktop',
+      }
+      const expected = {
+        ...data,
+        transactionAdjustedTotal: 40,
+        transactionAffiliation: 'email',
+        transactionId: '123',
+        transactionTotal: '20',
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: email,
+        price: 20,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce(data)).to.eql(expected)
+    })
+    it('checks transactionAdjustedTotal is 1.75 times of transactionTotal for desktop email lead with campaign_id', function() {
+      document.cookie = 'rp_session_id=abc'
+      document.cookie = 'campaign_id=12345'
+      const reducer = new EcommerceReducer()
+      const data = {
+        action: 'lead_submission',
+        listing_id: '1234',
+        selection: 'email',
+        revenue: '20',
+        screen_type: 'desktop',
+      }
+      const expected = {
+        ...data,
+        transactionAdjustedTotal: 35,
+        transactionAffiliation: 'email',
+        transactionId: '123',
+        transactionTotal: '20',
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: email,
+        price: 20,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce(data)).to.eql(expected)
+    })
+    it('checks transactionAdjustedTotal is same as transactionTotal for desktop phone leads', function() {
+      document.cookie = 'rp_session_id=abc'
+      document.cookie = 'campaign_id=12345'
+      const reducer = new EcommerceReducer()
+      const data = {
+        action: 'lead_submission',
+        listing_id: '1234',
+        selection: 'phone',
+        revenue: '20',
+        screen_type: 'desktop',
+      }
+      const expected = {
+        ...data,
+        transactionAdjustedTotal: 20,
+        transactionAffiliation: 'phone',
+        transactionId: '123',
+        transactionTotal: '20',
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: phone,
+        price: 20,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce(data)).to.eql(expected)
+    })
+    it('checks transactionAdjustedTotal is same as transactionTotal for mobile email leads', function() {
+      document.cookie = 'rp_session_id=abc'
+      document.cookie = 'campaign_id=12345'
+      const reducer = new EcommerceReducer()
+      const data = {
+        action: 'lead_submission',
+        listing_id: '1234',
+        selection: 'email',
+        revenue: '20',
+        screen_type: 'mobile',
+      }
+      const expected = {
+        ...data,
+        transactionAdjustedTotal: 20,
+        transactionAffiliation: 'email',
+        transactionId: '123',
+        transactionTotal: '20',
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: email,
+        price: 20,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce(data)).to.eql(expected)
+    })
+    it('checks transactionAdjustedTotal is same as transactionTotal for mobile phone leads', function() {
+      document.cookie = 'rp_session_id=abc'
+      document.cookie = 'campaign_id=12345'
+      const reducer = new EcommerceReducer()
+      const data = {
+        action: 'lead_submission',
+        listing_id: '1234',
+        selection: 'phone',
+        revenue: '20',
+        screen_type: 'mobile',
+      }
+      const expected = {
+        ...data,
+        transactionAdjustedTotal: 20,
+        transactionAffiliation: 'phone',
+        transactionId: '123',
+        transactionTotal: '20',
+        uniqueSubmission: 'true',
+        transactionProducts: `[{
+        sku: 1234,
+        name: 1234,
+        category: phone,
+        price: 20,
+        quantity: 1,
+      }]`,
+      }
+      expect(reducer.reduce(data)).to.eql(expected)
+    })
+  })
+})


### PR DESCRIPTION
For GTM standard ecommerce tags the event needs transactions tags. Adding Ecommerce reducer which will check for action type **lead_submission** and add in ecommerece tags

[New Feature - ecommence tags adjustment price](https://rentpath.leankit.com/card/692947967)

[Needed for Rentals-js PR](https://github.com/rentpath/rentals-js/pull/402)