### PR TITLE
Add ignore action to prevent duplicate tracking calls

### DIFF
--- a/src/EventTracker.js
+++ b/src/EventTracker.js
@@ -2,7 +2,10 @@ import emitter from './utils/emitter'
 import sanitize from './utils/sanitize'
 import initModule from './utils/initModule'
 import configurable from './utils/configurable'
-import { VIEW_ACTION } from './const'
+import {
+  IGNORE_ACTION,
+  VIEW_ACTION,
+} from './const'
 
 @emitter
 @configurable
@@ -18,6 +21,14 @@ export default class EventTracker {
 
   track(action, props) {
     const data = this._process(Object.assign({ action }, this._data, props))
+
+    // Do not track if the event has been marked to be ignored.
+    // This should be used only when you are manually calling the track function
+    // instead of relying on the automatic click tracking.
+    if (data.action === IGNORE_ACTION) {
+      return this
+    }
+
     this.trigger(action, data)
     this.providers.forEach(provider => provider.track(data))
     return this

--- a/src/const.js
+++ b/src/const.js
@@ -1,1 +1,2 @@
 export const VIEW_ACTION = 'view'
+export const IGNORE_ACTION = 'ignore'

--- a/test/EventTracker.js
+++ b/test/EventTracker.js
@@ -69,6 +69,13 @@ describe('EventTracker', function() {
       this.tracker.track('test')
       expect(spy.called).to.be.true
     })
+
+    it('does not trigger an event due to ignore override', function() {
+      const spy = sinon.spy()
+      this.tracker.on('test', spy)
+      this.tracker.track('test', { action: 'ignore' })
+      expect(spy.called).to.be.false
+    })
   })
 
   describe('#view', function() {


### PR DESCRIPTION
In some cases we manually perform a tracking call - for example:
- to send some dynamically-computed values like the ranges of prices in a slider component
- to record the click of a map pin that doesn't have HTML attributes

In those cases, the tracking call goes through, but event-tracker also gets the click as it bubbles up the DOM, so we end up with two tracking calls:
- the manual call with the data we want
- a second call that usually is ignored because it contains no useful info

It would useful in these cases to prevent the second tracking call.

## Todo

- [x] Unit tests

## HTML Attributes

Using the existing `data-tag` attributes, this PR checks for an `ignore` action, and if found, it prevents the tracking call. For example:

```
<script>
function manuallyTrack() {
  window.eventTracker.track( 'click', { item: 'slider_price', value: `min_${minPrice}-max_${maxPrice}` })
}
</script>
<button data-tag_action="ignore" onClick="manuallyTrack()">No automatic tracking</button>
```

Previously, clicking the button would make two calls (one with the desired info, the other an extra call that is not used).

Now, clicking the button would make the desired call, and because the button is marked with an "ignore" action, the second call would not occur.

### Sections

Entire sections can be marked to be ignored:
```
<div data-tag_action="ignore">
  Anything within this div will ignore the automatic tracking.
</div>
```

And you can override for specific controls if desired:
```
<div data-tag_action="ignore">
  Anything within this div will ignore the automatic tracking.
  <button data-tag_action="click">Except for this button</button>
</div>
```
