### PR TITLE
Delay gtm.view event until after Window Load event

### DIFF
--- a/src/providers/GoogleTagManager.js
+++ b/src/providers/GoogleTagManager.js
@@ -25,6 +25,7 @@ export default class GoogleTagManager {
     const { trackCallback, trackTimeout } = this.config
 
     const newData = { ...data }
+    let initialPageview = 1
 
     if (trackCallback) {
       // If you specify eventCallback in the data layer,
@@ -42,7 +43,40 @@ export default class GoogleTagManager {
       newData.eventTimeout = trackTimeout
     }
 
-    window.dataLayer.push(newData)
+    const delayedPageview = []
+
+    const trackDelayedPageView = () => {
+      if (
+        window.google_tag_manager &&
+        window.google_tag_manager.dataLayer &&
+        window.google_tag_manager.dataLayer.gtmLoad) {
+        delayedPageview.map(delayedData => window.dataLayer.push(delayedData))
+      } else {
+        // call trackDelayedPageview again
+        // to ensure dataLayer.gtmLoad is true
+        setTimeout(trackDelayedPageView, 100)
+      }
+    }
+
+    window.addEventListener('load', trackDelayedPageView)
+
+    // Tagging team requests that all initial gtm.view
+    // events be flagged with initialPageview=1
+    if (newData.event === 'gtm.view' && initialPageview === 1) {
+      newData.initialPageview = 1
+      initialPageview = 0
+    } else {
+      newData.initialPageview = 0
+    }
+
+    // we don't want `gtm.view` to fire before the default
+    // Page View and Window Loaded events
+    // but want the data, so delay in until after those events
+    if (document.readyState !== 'complete' && newData.event === 'gtm.view') {
+      delayedPageview.push(newData)
+    } else {
+      window.dataLayer.push(newData)
+    }
   }
 
   loadWithData(reducerModules) {


### PR DESCRIPTION
[Issue](https://app.zenhub.com/workspace/o/rentpath/event-tracker.js/issues/21)

- `gtm.view` should never be fired before `Window Loaded`
- first `gtm.view` on the page should be flagged with `initialPageview = 1`


![screen shot 2018-10-04 at 12 17 23 pm](https://user-images.githubusercontent.com/1353235/46500333-7040ef80-c7d7-11e8-87b3-5eb1612d3c0d.png)
