### PR TITLE
Round transactionAdjustedTotal to two decimals

### DIFF
--- a/src/reducers/Ecommerce.js
+++ b/src/reducers/Ecommerce.js
@@ -39,7 +39,7 @@ export default class EcommerceReducer {
   }
 
   adjustedTotal(factor, revenue) {
-    return revenue && !isNaN(revenue) ? (parseFloat(revenue) * factor)
+    return revenue && !isNaN(revenue) ? (parseFloat(revenue) * factor).toFixed(2)
       : revenue
   }
 

--- a/test/reducers/Ecommerce.js
+++ b/test/reducers/Ecommerce.js
@@ -105,7 +105,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 40,
+        transactionAdjustedTotal: '40.00',
         transactionAffiliation: 'email',
         transactionId: '123',
         transactionTotal: '20',
@@ -136,7 +136,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 35,
+        transactionAdjustedTotal: '35.00',
         transactionAffiliation: 'email',
         transactionId: '123',
         transactionTotal: '20',
@@ -168,7 +168,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 40,
+        transactionAdjustedTotal: '40.00',
         transactionAffiliation: 'email',
         transactionId: '123',
         transactionTotal: '20',
@@ -196,7 +196,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 20,
+        transactionAdjustedTotal: '20.00',
         transactionAffiliation: 'phone',
         transactionId: '123',
         transactionTotal: '20',
@@ -224,7 +224,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 20,
+        transactionAdjustedTotal: '20.00',
         transactionAffiliation: 'email',
         transactionId: '123',
         transactionTotal: '20',
@@ -252,7 +252,7 @@ describe('EcommerceReducer', function() {
       }
       const expected = {
         ...data,
-        transactionAdjustedTotal: 20,
+        transactionAdjustedTotal: '20.00',
         transactionAffiliation: 'phone',
         transactionId: '123',
         transactionTotal: '20',


### PR DESCRIPTION
Round transactionAdjustedTotal to two decimals and update tests to reflect changes.

Having more than three decimal places causes the Bing tag to not fire.