### PR TITLE
implement gtm.pageinfo

### DIFF
--- a/src/providers/GoogleTagManager.js
+++ b/src/providers/GoogleTagManager.js
@@ -73,6 +73,9 @@ export default class GoogleTagManager {
     // Page View and Window Loaded events
     // but want the data, so delay in until after those events
     if (document.readyState !== 'complete' && newData.event === 'gtm.view') {
+      // clone data and send it with a new event name
+      window.dataLayer.push({ ...newData, event: 'gtm.pageinfo' })
+      // send gtm.view later
       delayedPageview.push(newData)
     } else {
       window.dataLayer.push(newData)


### PR DESCRIPTION
![screen shot 2018-11-28 at 12 32 09 pm](https://user-images.githubusercontent.com/1353235/49180512-bfa02980-f309-11e8-8908-e7e7dbceb869.png)

Tagging requests the addition of a new event called `gtm.pageinfo` for GTM.
This is to send the data for the delayed `gtm.view` event, so it can be collected earlier, while `gtm.view` is delayed and will eventually trigger subsequent tags.