### PR TITLE
initialPageview should be 0 on SPA transition

### DIFF
--- a/src/providers/GoogleTagManager.js
+++ b/src/providers/GoogleTagManager.js
@@ -1,5 +1,7 @@
 import configurable from '../utils/configurable'
 
+let initialPageview = 1
+
 @configurable
 export default class GoogleTagManager {
 
@@ -25,7 +27,6 @@ export default class GoogleTagManager {
     const { trackCallback, trackTimeout } = this.config
 
     const newData = { ...data }
-    let initialPageview = 1
 
     if (trackCallback) {
       // If you specify eventCallback in the data layer,

--- a/src/reducers/Device.js
+++ b/src/reducers/Device.js
@@ -1,20 +1,5 @@
 import Parser from 'ua-parser-js'
 
-const screenSizeType = {
-  mobile: {
-    min: 0,
-    max: 480,
-  },
-  tablet: {
-    min: 481,
-    max: 1145,
-  },
-  desktop: {
-    min: 1146,
-    max: 99999,
-  },
-}
-
 export default class DeviceReducer {
   constructor(config) {
     this.config = Object.assign(this.defaults, config)
@@ -42,24 +27,7 @@ export default class DeviceReducer {
     return `${window.screen.width}x${window.screen.height}`
   }
 
-  isScreenSize(width) {
-    return ['mobile', 'tablet'].find(size => {
-      const type = screenSizeType[size]
-      return width >= type.min && width <= type.max
-    })
-  }
-
   get screenType() {
-    // We want to set the screen_type based pixel size and not via the
-    // userAgent to align with how GA handles attribution
-    const width = window.screen.width
-
-    if (width > 0) {
-      return this.isScreenSize(width) || 'desktop'
-    }
-
-    // Fallback to our old logic of using the device userAgent to figure out
-    // screen_type
     const type = this.parser.getDevice().type
     return this.config.enabledTypes[type] ? type : this.config.defaultType
   }

--- a/test/reducers/Device.js
+++ b/test/reducers/Device.js
@@ -69,12 +69,5 @@ describe('DeviceReducer', function() {
       this.reducer.config.enabledTypes.tablet = false
       expect(this.reducer.reduce().screen_type).to.equal('desktop')
     })
-    it('identifies tablet us sets mobile devices', function() {
-      // If you put tests below this you will need to reset or change
-      // global.window
-      global.window = { screen: { width: 410 } }
-      this.reducer.parser.setUA(agents.tablet)
-      expect(this.reducer.reduce().screen_type).to.equal('mobile')
-    })
   })
 })


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/TIDE-785)

## How to test:
- Load ag.js
- Check dataLayer in console
-- initialPageview should be set to 1
- search for city/state
- check dataLayer in console
-- initialPageview should be set to 0 for this view event and all subsequent events where the page is loaded from SPA transition.  Visiting site from a URL entry should have an initialPageview of 1